### PR TITLE
minor change for MSVC Codegen v140_clang_c2

### DIFF
--- a/includes/named_types/named_tuple.hpp
+++ b/includes/named_types/named_tuple.hpp
@@ -219,8 +219,7 @@ inline constexpr auto apply(Func&& f, named_tuple<Types...> const& in) -> declty
 
 namespace std {
 template <size_t Index, class... Tags>
-class tuple_element<Index, named_types::named_tuple<Tags...>> {
- public:
+struct tuple_element<Index, named_types::named_tuple<Tags...>> {
   using type =
       tuple_element_t<Index, tuple<named_types::__ntuple_tag_elem_t<Tags>...>>;
 };


### PR DESCRIPTION
I needed this minor change to compile with Clang (3.8) under MSVC:
tuple_element<> changed to struct to avoid warning (it is a specialization of a struct template)

This worked for me also on other compilers / stdlibs (GCC, MSVC), but I did not try it on CLANG on Linux, so I am not sure it is a correct modification (may be other std library implementation define tuple_element<> as a class?

By the way, thanks for your absolutely great job!
Tullio

