### PR TITLE
Patch for std::get<>() problem with Windows LLVM clang 

### DIFF
--- a/includes/named_types/named_tuple.hpp
+++ b/includes/named_types/named_tuple.hpp
@@ -27,6 +27,48 @@ template <class Spec, class Arg> struct __ntuple_tag_notation<Arg(Spec)> {
 template <class T>
 using __ntuple_tag_notation_t = typename __ntuple_tag_notation<T>::type;
 
+// forward declaration
+template < class ... Types>
+struct named_tuple;
+
+} // namespace named_types
+
+
+// Standard specialization
+
+namespace std {
+
+template <size_t Index, class... Tags>
+struct tuple_element<Index, named_types::named_tuple<Tags...>> {
+  using type =
+      tuple_element_t<Index, tuple<named_types::__ntuple_tag_elem_t<Tags>...>>;
+};
+
+template <size_t Index, class... Tags> inline
+constexpr typename tuple_element<Index, named_types::named_tuple<Tags...>>::type&
+    get (named_types::named_tuple<Tags...>& in)
+{	return get<Index> (static_cast<typename named_types::named_tuple<Tags...>::tuple_type&>(in));
+}
+
+template <size_t Index, class... Tags> inline
+constexpr const typename tuple_element<Index, named_types::named_tuple<Tags...>>::type&
+    get (const named_types::named_tuple<Tags...>& in)
+{	return get<Index> (static_cast<const typename named_types::named_tuple<Tags...>::tuple_type&>(in));
+}
+
+template <size_t Index, class... Tags> inline
+constexpr typename tuple_element<Index, named_types::named_tuple<Tags...>>::type&&
+    get (named_types::named_tuple<Tags...>&& in)
+{	return move (get<Index> (static_cast<typename named_types::named_tuple<Tags...>::tuple_type&&>(in)));
+}
+
+} // namespace std
+
+// end Standard specialization
+
+
+namespace named_types {
+
 template <class... Types>
 struct named_tuple : public std::tagged_tuple<__ntuple_tag_notation_t<Types>...>
                      // struct named_tuple : std::tagged_tuple< Types ...
@@ -215,12 +257,3 @@ inline constexpr auto apply(Func&& f, named_tuple<Types...> const& in) -> declty
 
 } // namespace named_types
 
-// Standard specialization
-
-namespace std {
-template <size_t Index, class... Tags>
-struct tuple_element<Index, named_types::named_tuple<Tags...>> {
-  using type =
-      tuple_element_t<Index, tuple<named_types::__ntuple_tag_elem_t<Tags>...>>;
-};
-} // namespace std

--- a/includes/std/experimental/tagged.hpp
+++ b/includes/std/experimental/tagged.hpp
@@ -56,6 +56,7 @@ struct __getters {
 template <class Base, class... Tags>
 struct tagged : Base, __getters::collect<tagged<Base, Tags...>, Tags...> {
   using Base::Base;
+  using base_tuple = Base;
   tagged() = default;
   tagged(tagged&&) = default;
   tagged(const tagged&) = default;
@@ -231,20 +232,20 @@ template <class... Types> struct tagged_tuple : __tagged_tuple<Types...> {
 template <class Tag, class... Types>
 typename tagged_tuple<Types...>::template type_at<Tag>::raw_type const&
 get(tagged_tuple<Types...> const& input) {
-  return get<tagged_tuple<Types...>::template tag_index<Tag>::value>(input);
+  return get<tagged_tuple<Types...>::template tag_index<Tag>::value>(static_cast<typename tagged_tuple<Types...>::base_tuple const&>(input));
 };
 
 template <class Tag, class... Types>
 typename tagged_tuple<Types...>::template type_at<Tag>::raw_type&
 get(tagged_tuple<Types...>& input) {
-  return get<tagged_tuple<Types...>::template tag_index<Tag>::value>(input);
+  return get<tagged_tuple<Types...>::template tag_index<Tag>::value>(static_cast<typename tagged_tuple<Types...>::base_tuple&>(input));
 };
 
 template <class Tag, class... Types>
 typename tagged_tuple<Types...>::template type_at<Tag>::raw_type&&
 get(tagged_tuple<Types...>&& input) {
   return move(get<tagged_tuple<Types...>::template tag_index<Tag>::value>(
-      std::forward<tagged_tuple<Types...>>(input)));
+      std::forward<tagged_tuple<Types...>>(static_cast<typename tagged_tuple<Types...>::base_tuple &&>(input))));
 };
 
 namespace tag {

--- a/includes/std/experimental/tagged.hpp
+++ b/includes/std/experimental/tagged.hpp
@@ -260,10 +260,10 @@ struct basic_tag {
     ~getter() = default;
 
    private:
-    friend struct __getters;
+    friend struct std::__getters;
   };
 
-  friend struct __getters;
+  friend struct std::__getters;
 };
 }
 }


### PR DESCRIPTION
These patches are required in order to build on Windows with LLVM clang 5.0 toolset (either with mingw or with MSVC using LLVM-vs2014 toolset).

Basically, the encountered problem is that, under certain (many) conditions, `std::get<>()` is not able to cast a `named_tuple<>` or a `tagged_tuple<>` to its base `std::tuple<>`. 
This is the case, for instance, of the `named_tuple::operator[]`.

I believe this is a bug of the Windows version of LLVM clang distribution, anyways the patched code introduces no overhead and is quite simple.

The proposed solution implements to patches:
- an explicitly cast to the base `std::tuple<>` in `std::get<>()` calls in `tagged.hpp` (a simple solution, yet nor general as other client code may use `std::get<>()` on a` tagged_tuple<>`);
- ovverridden `std::get<>()` functions for `named_tuple<>` in `named_tuple.hpp` (a bit longer solution, but more general, also fixes al client code that uses `std::get<>()` on `named_tuple<>` and, as far as I have seen, on any other derived classes).

I'd be curious to know your opinion on this strange LLVM 'bug', and if you can imagine better solutions (other than working on Linux :)).

Follows a sample error log:

```
  In file included from D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\0lf\0lf/internal/logger_def_dumpers.hh:23:
1>D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\0lf\..\named_types\includes\named_types/named_tuple.hpp(170,12): error : no matching function for call to 'get'
1>      return std::get<
1>             ^~~~~~~~~
1>  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\0lf\src\process_monitor.cpp(132,23):  note: in instantiation of function template specialization 'named_types::named_tuple<unsigned long long (named_types::named_tag<named_types::string_literal<char, 'a', 'c', 't', 'o', 'r', 's'> >), double (named_types::named_tag<named_types::string_literal<char, 'm', 'o', 'd', '_', 'c', 'p', 'u'> >), double (named_types::named_tag<named_types::string_literal<char, 's', 'y', 's', '_', 'c', 'p', 'u'> >), unsigned long long (named_types::named_tag<named_types::string_literal<char, 'm', 'o', 'd', '_', 'r', 'a', 'm'> >), std::basic_string<char, std::char_traits<char>, std::allocator<char> > (named_types::named_tag<named_types::string_literal<char, 't', 'r', 'a', 'c', 'e', '_', 'm', 'o', 'd', 'e'> >), unsigned long long (named_types::named_tag<named_types::string_literal<char, 's', 'y', 's', '_', 'f', 'r', 'e', 'e', '_', 'r', 'a', 'm'> >)>::operator[]<named_types::string_literal<char, 'a', 'c', 't', 'o', 'r', 's'> >' requested here
1>                  info_ [_(actors)] = home_system().registry().running();
1>                        ^
1>  C:\apps\MSStudio2015\VC\include\utility(518,3):  note: candidate template ignored: could not match 'pair' against 'named_tuple'
1>                  get(pair<_Ty1, _Ty2>& _Pr) _NOEXCEPT
1>                  ^
1>  C:\apps\MSStudio2015\VC\include\utility(542,3):  note: candidate template ignored: could not match 'pair' against 'named_tuple'
1>                  get(const pair<_Ty1, _Ty2>& _Pr) _NOEXCEPT
1>                  ^
1>  C:\apps\MSStudio2015\VC\include\utility(567,3):  note: candidate template ignored: could not match 'pair' against 'named_tuple'
1>                  get(pair<_Ty1, _Ty2>&& _Pr) _NOEXCEPT
1>                  ^
1>  C:\apps\MSStudio2015\VC\include\tuple(882,3):  note: candidate template ignored: failed template argument deduction
1>                  get(tuple<_Types...>& _Tuple) _NOEXCEPT
1>                  ^
1>  C:\apps\MSStudio2015\VC\include\tuple(892,3):  note: candidate template ignored: failed template argument deduction
1>                  get(const tuple<_Types...>& _Tuple) _NOEXCEPT
1>                  ^
1>  C:\apps\MSStudio2015\VC\include\tuple(902,3):  note: candidate template ignored: failed template argument deduction
1>                  get(tuple<_Types...>&& _Tuple) _NOEXCEPT
1>                  ^
1>  C:\apps\MSStudio2015\VC\include\array(493,17):  note: candidate template ignored: could not match 'array' against 'named_tuple'
1>          constexpr _Ty& get(array<_Ty, _Size>& _Arr) _NOEXCEPT
1>                         ^
1>  C:\apps\MSStudio2015\VC\include\array(502,23):  note: candidate template ignored: could not match 'array' against 'named_tuple'
1>          constexpr const _Ty& get(const array<_Ty, _Size>& _Arr) _NOEXCEPT
1>                               ^
1>  C:\apps\MSStudio2015\VC\include\array(511,18):  note: candidate template ignored: could not match 'array' against 'named_tuple'
1>          constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) _NOEXCEPT
1>                          ^
1>  C:\apps\MSStudio2015\VC\include\utility(526,18):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty1'
1>          constexpr _Ty1& get(pair<_Ty1, _Ty2>& _Pr) _NOEXCEPT
1>                          ^
1>  C:\apps\MSStudio2015\VC\include\utility(533,18):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty2'
1>          constexpr _Ty2& get(pair<_Ty1, _Ty2>& _Pr) _NOEXCEPT
1>                          ^
1>  C:\apps\MSStudio2015\VC\include\utility(551,24):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty1'
1>          constexpr const _Ty1& get(const pair<_Ty1, _Ty2>& _Pr) _NOEXCEPT
1>                                ^
1>  C:\apps\MSStudio2015\VC\include\utility(558,24):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty2'
1>          constexpr const _Ty2& get(const pair<_Ty1, _Ty2>& _Pr) _NOEXCEPT
1>                                ^
1>  C:\apps\MSStudio2015\VC\include\utility(575,19):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty1'
1>          constexpr _Ty1&& get(pair<_Ty1, _Ty2>&& _Pr) _NOEXCEPT
1>                           ^
1>  C:\apps\MSStudio2015\VC\include\utility(582,19):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty2'
1>          constexpr _Ty2&& get(pair<_Ty1, _Ty2>&& _Pr) _NOEXCEPT
1>                           ^
1>  C:\apps\MSStudio2015\VC\include\tuple(914,17):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty'
1>          constexpr _Ty& get(tuple<_Types...>& _Tuple) _NOEXCEPT
1>                         ^
1>  C:\apps\MSStudio2015\VC\include\tuple(922,23):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty'
1>          constexpr const _Ty& get(const tuple<_Types...>& _Tuple) _NOEXCEPT
1>                               ^
1>  C:\apps\MSStudio2015\VC\include\tuple(930,18):  note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Ty'
1>          constexpr _Ty&& get(tuple<_Types...>&& _Tuple) _NOEXCEPT
1>                          ^
1>  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\0lf\..\named_types\includes\std/experimental/tagged.hpp(233,1):  note: candidate template ignored: invalid explicitly-specified argument for template parameter 'Tag'
1>  get(tagged_tuple<Types...> const& input) {
1>  ^
1>  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\0lf\..\named_types\includes\std/experimental/tagged.hpp(239,1):  note: candidate template ignored: invalid explicitly-specified argument for template parameter 'Tag'
1>  get(tagged_tuple<Types...>& input) {
1>  ^
1>  D:\Users\Tulmenga\Projects\prj_0lf\factory_0lf\0lf\..\named_types\includes\std/experimental/tagged.hpp(245,1):  note: candidate template ignored: invalid explicitly-specified argument for template parameter 'Tag'
1>  get(tagged_tuple<Types...>&& input) {
1>  ^

```